### PR TITLE
tweak(warnings): use append mode for nowarn

### DIFF
--- a/Elements.Core/Elements.Core.csproj
+++ b/Elements.Core/Elements.Core.csproj
@@ -15,13 +15,13 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>11</LangVersion>
     <DocumentationFile>bin\Release\Elements.Core.xml</DocumentationFile>
-    <NoWarn>CS0649, CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS0649;CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseProfile|AnyCPU'">
     <OutputPath>bin\ReleaseProfile\</OutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Optimize>true</Optimize>
-    <NoWarn>CS0649, CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS0649;CS1591</NoWarn>
     <LangVersion>11</LangVersion>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <DefineConstants>PROFILE</DefineConstants>


### PR DESCRIPTION
I've been meaning to do this for many months, with this now being Open Source its actually somewhat easier. \o/

---

Historically Ive had a lot of issues turning of or modifying warnings when dealing with FrooxEngine code. It turns out that there are many causes for this, but one of them is how we use `<NoWarn>` in our CSProj'es.

The way, these are currently being set overwrites any previous or higher(SLN, CLI, CI) etc values for warnings. The end result of this is that it actually turns back on ALL warnings except for the two listed.

This PR swaps our use of NoWarn to be an Append operation not an Absolute set. This way previous NoWarn values are included.

You can read about this here: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/errors-warnings#nowarn

