### PR TITLE
Fixed RecyclableMemoryStream.WriteFrom corruption

### DIFF
--- a/Elements.Core.Tests/RecyclableMemoryStream/RecyclableMemoryStreamTests.cs
+++ b/Elements.Core.Tests/RecyclableMemoryStream/RecyclableMemoryStreamTests.cs
@@ -1,0 +1,34 @@
+﻿using System.IO.Pipes;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Elements.Core.Tests;
+
+[TestClass]
+public class RecyclableMemoryStreamTests
+{
+    [TestMethod]
+    public async Task WriteFromPartialBuffer()
+    {
+        await using var pipeServer = new AnonymousPipeServerStream(PipeDirection.Out);
+
+        pipeServer.Write(new byte[]{1, 2, 3, 4, 5});
+        
+        var handle = pipeServer.ClientSafePipeHandle;
+        var child = Task.Run(async () =>
+        {
+            await using var pipeClient = new AnonymousPipeClientStream(PipeDirection.In, handle);
+            var manager = new RecyclableMemoryStreamManager();
+            await using var recycleStream = new RecyclableMemoryStream(manager, null , 100);
+
+            recycleStream.WriteFrom(pipeClient, 10);
+            return recycleStream.ToArray();
+        });
+        
+        await Task.Delay(10);
+        pipeServer.Write(new byte[]{6, 7, 8, 9, 10});
+        var memory = await child;
+        
+        CollectionAssert.AreEqual(new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, memory);
+    }
+}

--- a/Elements.Core/RecyclableMemoryStream/RecyclableMemoryStream.cs
+++ b/Elements.Core/RecyclableMemoryStream/RecyclableMemoryStream.cs
@@ -633,7 +633,7 @@ namespace Elements.Core
             {
                 int toRead = Math.Min(length, copyBuffer.Length);
 
-                stream.Read(copyBuffer, 0, toRead);
+                stream.ReadExactly(copyBuffer, 0, toRead);
                 Write(copyBuffer, 0, toRead);
 
                 length -= toRead;


### PR DESCRIPTION
See #19, the memory stream corrupts if the sender was slow to emit data.

I verified the test fails without the patch, only the first 5 numbers are in the stream, the rest are zeros.

The issue was flagged by a compiler warning, https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2022 