### PR TITLE
Item-Group cleanups

### DIFF
--- a/Elements.Core/Elements.Core.csproj
+++ b/Elements.Core/Elements.Core.csproj
@@ -27,14 +27,6 @@
     <DefineConstants>PROFILE</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Remove="Animation\**" />
-    <Compile Remove="Modifiers\**" />
-    <EmbeddedResource Remove="Animation\**" />
-    <EmbeddedResource Remove="Modifiers\**" />
-    <None Remove="Animation\**" />
-    <None Remove="Modifiers\**" />
-  </ItemGroup>
-  <ItemGroup>
     <Compile Update="Data Types\HalfVectors.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
@@ -179,12 +171,6 @@
       <Generator>TextTemplatingFileGenerator</Generator>
       <LastGenOutput>PrimitiveTryParsers.cs</LastGenOutput>
     </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
-  </ItemGroup>
-  <ItemGroup>
-    <Folder Include="RecyclableMemoryStream\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CodeGenerationConfig\CodeGenerationConfig.csproj" />


### PR DESCRIPTION
Remove item groups that seem like they're from old migrations, and no longer correlate to files (or services) in the repo. Or that are automatically included.