### PR TITLE
Restore generation of XML docs

### DIFF
--- a/Elements.Core/Elements.Core.csproj
+++ b/Elements.Core/Elements.Core.csproj
@@ -6,6 +6,8 @@
 
     <PackageId>YellowDogMan.Elements.Core</PackageId>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Update="Data Types\HalfVectors.cs">


### PR DESCRIPTION
#22 removed the `Release|AnyCPU` PropertyGroup, which contained `<DocumentationFile>`, so no `Elements.Core.xml` is produced any more. This re-enables it with `GenerateDocumentationFile`.

One heads-up for the Resonite side: this alone won't put `Elements.Core.xml` back in the install directory. It's already missing in 2026.7.28.1272, which was built while `<DocumentationFile>` was still in place. Your CI may need an explicit copy step for it.