### PR TITLE
Added missing hash and equality members for classes that implemented equality comparers.

### DIFF
--- a/CodeGenerationConfig/Config.cs
+++ b/CodeGenerationConfig/Config.cs
@@ -46,7 +46,15 @@ namespace CodeGenerationConfig
             this.Columns = columns;
         }
 
-        public bool Equals(MatrixSize other) => Rows == other.Rows && Columns == other.Columns;
+        public override bool Equals(object obj)
+        {
+            if (obj is null) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            if (obj.GetType() != GetType()) return false;
+            return Equals((MatrixSize)obj);
+        }
+
+        public bool Equals(MatrixSize other) => other != null && Rows == other.Rows && Columns == other.Columns;
 
         public static bool operator ==(MatrixSize left, MatrixSize right)
         {
@@ -60,6 +68,14 @@ namespace CodeGenerationConfig
         }
 
         public static bool operator !=(MatrixSize left, MatrixSize right) => !(left == right);
+        
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (Rows * 397) ^ Columns;
+            }
+        }
     }
 
     public static class Config

--- a/Elements.Core.Tests/String/StringSegment.cs
+++ b/Elements.Core.Tests/String/StringSegment.cs
@@ -3,6 +3,12 @@
     [TestClass]
     public class StringSegmentTests
     {
+        const string POTATOES = "Potatoes";
+
+        // Four characters long, so it doubles as the offset of POTATOES when the two are
+        // concatenated.
+        const string MAYO = "Mayo";
+
         [TestMethod]
         public void TestTrim()
         {
@@ -27,7 +33,7 @@
         [DataRow(5, "abcde", "fg")]
         [DataRow(6, "abcdef", "g")]
         [DataRow(7, "abcdefg", "")]
-        [DataTestMethod]
+        [TestMethod]
         public void TestSplit(int index, string leftExpected, string rightExpected)
         {
             var segment = new StringSegment(" abcdefg ");
@@ -44,7 +50,7 @@
         [DataRow("+")]
         [DataRow("AND")]
         [DataRow(" --> ")]
-        [DataTestMethod]
+        [TestMethod]
         public void TestSplitAround(string separator)
         {
             const string A = "Potatoes";
@@ -93,6 +99,58 @@
             var actual = segment.LastIndexOf(SUBSTRING);
 
             Assert.AreEqual(expected, actual);
+        }
+
+        // Segments hash ordinally, the same way the equivalent string does, so the two can
+        // share a hash based lookup.
+        [DataRow(POTATOES, POTATOES, 0, DisplayName = "Whole string")]
+        [DataRow(POTATOES, "  " + POTATOES + "  ", 2, DisplayName = "Slice out of a padded string")]
+        [DataRow("", "", 0, DisplayName = "Empty string")]
+        [DataRow("", POTATOES, 1, DisplayName = "Zero length slice")]
+        [TestMethod]
+        public void GetHashCode_Segment_MatchesTheEquivalentString(string expectedContent, string backingString, int offset)
+        {
+            var segment = new StringSegment(backingString, offset, expectedContent.Length);
+
+            var actual = segment.GetHashCode();
+
+            Assert.AreEqual(expectedContent.GetHashCode(), actual);
+        }
+
+        [TestMethod]
+        public void GetHashCode_DefaultSegment_MatchesTheEmptyString()
+        {
+            var segment = StringSegment.Empty;
+
+            var actual = segment.GetHashCode();
+
+            Assert.AreEqual(string.Empty.GetHashCode(), actual);
+        }
+
+        // The same text reached through two different backing strings has to hash
+        // identically, otherwise segments cannot be used as keys.
+        [DataRow(POTATOES, "  " + POTATOES + "  ", 2, DisplayName = "Slice out of a padded string")]
+        [DataRow(POTATOES, POTATOES + MAYO, 0, DisplayName = "Slice off the start of a longer string")]
+        [DataRow(POTATOES, MAYO + POTATOES, 4, DisplayName = "Slice off the end of a longer string")]
+        [TestMethod]
+        public void GetHashCode_SegmentsWithTheSameContent_ReturnsTheSameValue(string content, string backingString, int offset)
+        {
+            var whole = new StringSegment(content);
+            var sliced = new StringSegment(backingString, offset, content.Length);
+
+            Assert.AreEqual(whole.GetHashCode(), sliced.GetHashCode());
+        }
+
+        [DataRow(POTATOES, MAYO, DisplayName = "Unrelated content")]
+        [DataRow(POTATOES, "potatoes", DisplayName = "Differing only in case")]
+        [DataRow(POTATOES, "Potato", DisplayName = "Prefix of the other")]
+        [TestMethod]
+        public void GetHashCode_SegmentsWithDifferentContent_ReturnsDifferentValues(string left, string right)
+        {
+            var a = new StringSegment(left);
+            var b = new StringSegment(right);
+
+            Assert.AreNotEqual(a.GetHashCode(), b.GetHashCode());
         }
     }
 }

--- a/Elements.Core.Tests/String/StringSegmentTokenEquality.cs
+++ b/Elements.Core.Tests/String/StringSegmentTokenEquality.cs
@@ -1,0 +1,272 @@
+namespace Elements.Core.Tests;
+
+[TestClass]
+public class StringSegmentTokenEqualityTests
+{
+    const string HELLO = "hello";
+    const string PADDED_HELLO = "xxhelloxx";
+    const int HELLO_OFFSET = 2;
+    const int HELLO_LENGTH = 5;
+
+    // Same length as HELLO, so the comparison cannot short circuit on the length.
+    const string WORLD = "world";
+
+    // A prefix of HELLO, so the comparison differs only in length.
+    const int SHORTER_LENGTH = 4;
+
+    const string STORED_VALUE = "value";
+    const string REPLACEMENT_VALUE = "replaced";
+
+    // Built at runtime from chars, so it is not interned alongside the literals above,
+    // which forces Equals down the substring comparison path instead of the
+    // ReferenceEquals(WholeString, ...) fast path.
+    static string Uninterned(string value) => new string(value.ToCharArray());
+
+    static StringSegmentToken SlicedHello() => new(PADDED_HELLO, HELLO_OFFSET, HELLO_LENGTH);
+
+    static StringSegmentToken StandaloneHello() => new(Uninterned(HELLO));
+
+    public static IEnumerable<object[]> EqualTokens =>
+    [
+        ["the same backing string and range", SlicedHello(), SlicedHello()],
+        ["the same content out of different backing strings", SlicedHello(), StandaloneHello()],
+    ];
+
+    public static IEnumerable<object[]> UnequalTokens =>
+    [
+        ["different content of the same length", StandaloneHello(), new StringSegmentToken(WORLD)],
+        ["the same backing string over different lengths", new StringSegmentToken(HELLO, 0, HELLO_LENGTH), new StringSegmentToken(HELLO, 0, SHORTER_LENGTH)],
+    ];
+
+    public static IEnumerable<object[]> ValuesThatAreNotTokens =>
+    [
+        ["a raw string holding equal content", HELLO],
+        ["an unrelated type", 42],
+    ];
+
+    [TestMethod]
+    [DynamicData(nameof(EqualTokens))]
+    public void Equals_EqualTokens_ReturnsTrue(string scenario, StringSegmentToken a, StringSegmentToken b)
+    {
+        var actual = a.Equals(b);
+
+        Assert.IsTrue(actual, scenario);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(UnequalTokens))]
+    public void Equals_UnequalTokens_ReturnsFalse(string scenario, StringSegmentToken a, StringSegmentToken b)
+    {
+        var actual = a.Equals(b);
+
+        Assert.IsFalse(actual, scenario);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(EqualTokens))]
+    public void Equals_EqualTokensWithArgumentsSwapped_ReturnsTrue(string scenario, StringSegmentToken a, StringSegmentToken b)
+    {
+        var actual = b.Equals(a);
+
+        Assert.IsTrue(actual, scenario);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(UnequalTokens))]
+    public void Equals_UnequalTokensWithArgumentsSwapped_ReturnsFalse(string scenario, StringSegmentToken a, StringSegmentToken b)
+    {
+        var actual = b.Equals(a);
+
+        Assert.IsFalse(actual, scenario);
+    }
+
+    [TestMethod]
+    public void Equals_SameInstance_ReturnsTrue()
+    {
+        var token = SlicedHello();
+
+        var actual = token.Equals(token);
+
+        Assert.IsTrue(actual);
+    }
+
+    [TestMethod]
+    public void Equals_Null_ReturnsFalse()
+    {
+        var token = StandaloneHello();
+        StringSegmentToken none = null;
+
+        var actual = token.Equals(none);
+
+        Assert.IsFalse(actual);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(EqualTokens))]
+    public void EqualsObject_EqualTokens_ReturnsTrue(string scenario, StringSegmentToken a, StringSegmentToken b)
+    {
+        var actual = a.Equals((object)b);
+
+        Assert.IsTrue(actual, scenario);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(UnequalTokens))]
+    public void EqualsObject_UnequalTokens_ReturnsFalse(string scenario, StringSegmentToken a, StringSegmentToken b)
+    {
+        var actual = a.Equals((object)b);
+
+        Assert.IsFalse(actual, scenario);
+    }
+
+    [TestMethod]
+    public void EqualsObject_Null_ReturnsFalse()
+    {
+        var token = StandaloneHello();
+
+        var actual = token.Equals((object)null);
+
+        Assert.IsFalse(actual);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(ValuesThatAreNotTokens))]
+    public void EqualsObject_ValueThatIsNotAToken_ReturnsFalse(string description, object other)
+    {
+        var token = StandaloneHello();
+
+        var actual = token.Equals(other);
+
+        Assert.IsFalse(actual, description);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(EqualTokens))]
+    public void EqualityOperator_EqualTokens_ReturnsTrue(string scenario, StringSegmentToken a, StringSegmentToken b)
+    {
+        var actual = a == b;
+
+        Assert.IsTrue(actual, scenario);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(UnequalTokens))]
+    public void EqualityOperator_UnequalTokens_ReturnsFalse(string scenario, StringSegmentToken a, StringSegmentToken b)
+    {
+        var actual = a == b;
+
+        Assert.IsFalse(actual, scenario);
+    }
+
+    [TestMethod]
+    public void EqualityOperator_NullOnTheRight_ReturnsFalse()
+    {
+        var token = StandaloneHello();
+        StringSegmentToken none = null;
+
+        var actual = token == none;
+
+        Assert.IsFalse(actual);
+    }
+
+    [TestMethod]
+    public void EqualityOperator_NullOnTheLeft_ReturnsFalse()
+    {
+        var token = StandaloneHello();
+        StringSegmentToken none = null;
+
+        var actual = none == token;
+
+        Assert.IsFalse(actual);
+    }
+
+    [TestMethod]
+    public void EqualityOperator_NullOnBothSides_ReturnsTrue()
+    {
+        StringSegmentToken none = null;
+
+        var actual = none == null;
+
+        Assert.IsTrue(actual);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(EqualTokens))]
+    public void InequalityOperator_EqualTokens_ReturnsFalse(string scenario, StringSegmentToken a, StringSegmentToken b)
+    {
+        var actual = a != b;
+
+        Assert.IsFalse(actual, scenario);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(UnequalTokens))]
+    public void InequalityOperator_UnequalTokens_ReturnsTrue(string scenario, StringSegmentToken a, StringSegmentToken b)
+    {
+        var actual = a != b;
+
+        Assert.IsTrue(actual, scenario);
+    }
+
+    [TestMethod]
+    public void InequalityOperator_Null_ReturnsTrue()
+    {
+        var token = StandaloneHello();
+        StringSegmentToken none = null;
+
+        var actual = token != none;
+
+        Assert.IsTrue(actual);
+    }
+
+    // Equal tokens have to hash the same regardless of which string backs them,
+    // otherwise they cannot be used as keys.
+    [TestMethod]
+    [DynamicData(nameof(EqualTokens))]
+    public void GetHashCode_EqualTokens_ReturnsTheSameValue(string scenario, StringSegmentToken a, StringSegmentToken b)
+    {
+        var actual = a.GetHashCode();
+
+        Assert.AreEqual(b.GetHashCode(), actual, scenario);
+    }
+
+    [TestMethod]
+    public void AsDictionaryKey_EqualToken_FindsTheStoredValue()
+    {
+        var map = new Dictionary<StringSegmentToken, string> { [SlicedHello()] = STORED_VALUE };
+
+        var actual = map[StandaloneHello()];
+
+        Assert.AreEqual(STORED_VALUE, actual);
+    }
+
+    [TestMethod]
+    public void AsDictionaryKey_EqualToken_ReplacesTheExistingEntry()
+    {
+        var map = new Dictionary<StringSegmentToken, string> { [SlicedHello()] = STORED_VALUE };
+
+        map[StandaloneHello()] = REPLACEMENT_VALUE;
+
+        Assert.HasCount(1, map);
+    }
+
+    [TestMethod]
+    public void AsHashSetItem_UnequalToken_IsAdded()
+    {
+        var set = new HashSet<StringSegmentToken> { SlicedHello() };
+
+        var actual = set.Add(new StringSegmentToken(WORLD));
+
+        Assert.IsTrue(actual);
+    }
+
+    [TestMethod]
+    public void AsHashSetItem_EqualToken_IsRejectedAsADuplicate()
+    {
+        var set = new HashSet<StringSegmentToken> { SlicedHello() };
+
+        var actual = set.Add(StandaloneHello());
+
+        Assert.IsFalse(actual);
+    }
+}

--- a/Elements.Core.Tests/Types/RigidTransformEqualityTests.cs
+++ b/Elements.Core.Tests/Types/RigidTransformEqualityTests.cs
@@ -1,0 +1,143 @@
+namespace Elements.Core.Tests;
+
+[TestClass]
+public class RigidTransformEqualityTests
+{
+    static readonly float3 POSITION = new(1f, 2f, 3f);
+    static readonly float3 DIFFERENT_POSITION = new(4f, 2f, 3f);
+
+    static readonly floatQ ROTATION = floatQ.Euler(0f, 90f, 0f);
+    static readonly floatQ DIFFERENT_ROTATION = floatQ.Euler(0f, 95f, 0f);
+
+    // floatQ compares rotations approximately, and a thousandth of a degree sits well
+    // inside that tolerance.
+    static readonly floatQ NEGLIGIBLY_DIFFERENT_ROTATION = floatQ.Euler(0f, 90.001f, 0f);
+
+    // Built fresh on every call rather than shared, so the tests compare distinct
+    // instances, and a distinct box each time one is passed as an object.
+    static RigidTransform MakeRigidTransform(float3? position = null, floatQ? rotation = null) =>
+        new(position ?? POSITION, rotation ?? ROTATION);
+
+    public static IEnumerable<object[]> EqualRigidTransforms =>
+    [
+        ["the same components", MakeRigidTransform(), MakeRigidTransform()],
+        ["rotations within the approximate comparison tolerance", MakeRigidTransform(), MakeRigidTransform(rotation: NEGLIGIBLY_DIFFERENT_ROTATION)],
+    ];
+
+    public static IEnumerable<object[]> UnequalRigidTransforms =>
+    [
+        ["a different position", MakeRigidTransform(), MakeRigidTransform(position: DIFFERENT_POSITION)],
+        ["a different rotation", MakeRigidTransform(), MakeRigidTransform(rotation: DIFFERENT_ROTATION)],
+    ];
+
+    public static IEnumerable<object[]> ValuesThatAreNotRigidTransforms =>
+    [
+        ["null", null],
+        ["a string", "not a rigid transform"],
+        ["a Transform carrying the same position and rotation", new Transform(POSITION, ROTATION, float3.One)],
+    ];
+
+    [TestMethod]
+    [DynamicData(nameof(EqualRigidTransforms))]
+    public void Equals_EqualRigidTransforms_ReturnsTrue(string scenario, RigidTransform a, RigidTransform b)
+    {
+        var actual = a.Equals(b);
+
+        Assert.IsTrue(actual, scenario);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(UnequalRigidTransforms))]
+    public void Equals_UnequalRigidTransforms_ReturnsFalse(string scenario, RigidTransform a, RigidTransform b)
+    {
+        var actual = a.Equals(b);
+
+        Assert.IsFalse(actual, scenario);
+    }
+
+    [TestMethod]
+    public void Equals_SameInstance_ReturnsTrue()
+    {
+        var rigidTransform = MakeRigidTransform();
+
+        var actual = rigidTransform.Equals(rigidTransform);
+
+        Assert.IsTrue(actual);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(EqualRigidTransforms))]
+    public void EqualsObject_EqualRigidTransforms_ReturnsTrue(string scenario, RigidTransform a, RigidTransform b)
+    {
+        var actual = a.Equals((object)b);
+
+        Assert.IsTrue(actual, scenario);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(UnequalRigidTransforms))]
+    public void EqualsObject_UnequalRigidTransforms_ReturnsFalse(string scenario, RigidTransform a, RigidTransform b)
+    {
+        var actual = a.Equals((object)b);
+
+        Assert.IsFalse(actual, scenario);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(ValuesThatAreNotRigidTransforms))]
+    public void EqualsObject_ValueThatIsNotARigidTransform_ReturnsFalse(string description, object other)
+    {
+        var rigidTransform = MakeRigidTransform();
+
+        var actual = rigidTransform.Equals(other);
+
+        Assert.IsFalse(actual, description);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(EqualRigidTransforms))]
+    public void EqualityOperator_EqualRigidTransforms_ReturnsTrue(string scenario, RigidTransform a, RigidTransform b)
+    {
+        var actual = a == b;
+
+        Assert.IsTrue(actual, scenario);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(UnequalRigidTransforms))]
+    public void EqualityOperator_UnequalRigidTransforms_ReturnsFalse(string scenario, RigidTransform a, RigidTransform b)
+    {
+        var actual = a == b;
+
+        Assert.IsFalse(actual, scenario);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(EqualRigidTransforms))]
+    public void InequalityOperator_EqualRigidTransforms_ReturnsFalse(string scenario, RigidTransform a, RigidTransform b)
+    {
+        var actual = a != b;
+
+        Assert.IsFalse(actual, scenario);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(UnequalRigidTransforms))]
+    public void InequalityOperator_UnequalRigidTransforms_ReturnsTrue(string scenario, RigidTransform a, RigidTransform b)
+    {
+        var actual = a != b;
+
+        Assert.IsTrue(actual, scenario);
+    }
+
+    // Equal values are required to hash the same, but the hash mixes the rotation exactly
+    // while equality compares it approximately, so this pair hashes differently.
+    [TestMethod, Ignore("Known defect: rotations that compare approximately equal do not share a hash code.")]
+    public void GetHashCode_RotationsWithinTheApproximateComparisonTolerance_ReturnsTheSameValue()
+    {
+        var a = MakeRigidTransform();
+        var b = MakeRigidTransform(rotation: NEGLIGIBLY_DIFFERENT_ROTATION);
+
+        Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
+    }
+}

--- a/Elements.Core.Tests/Types/TransformEqualityTests.cs
+++ b/Elements.Core.Tests/Types/TransformEqualityTests.cs
@@ -1,0 +1,136 @@
+namespace Elements.Core.Tests;
+
+[TestClass]
+public class TransformEqualityTests
+{
+    static readonly float3 POSITION = new(1f, 2f, 3f);
+    static readonly float3 DIFFERENT_POSITION = new(4f, 2f, 3f);
+
+    static readonly floatQ ROTATION = floatQ.Euler(0f, 90f, 0f);
+    static readonly floatQ DIFFERENT_ROTATION = floatQ.Euler(0f, 95f, 0f);
+
+    // floatQ compares rotations approximately, and a thousandth of a degree sits well
+    // inside that tolerance.
+    static readonly floatQ NEGLIGIBLY_DIFFERENT_ROTATION = floatQ.Euler(0f, 90.001f, 0f);
+
+    static readonly float3 SCALE = new(0.5f, 0.25f, 0.125f);
+    static readonly float3 DIFFERENT_SCALE = float3.One;
+
+    // Built fresh on every call rather than shared, so the tests compare distinct
+    // instances, and a distinct box each time one is passed as an object.
+    static Transform MakeTransform(float3? position = null, floatQ? rotation = null, float3? scale = null) =>
+        new(position ?? POSITION, rotation ?? ROTATION, scale ?? SCALE);
+
+    public static IEnumerable<object[]> EqualTransforms =>
+    [
+        ["the same components", MakeTransform(), MakeTransform()],
+        ["rotations within the approximate comparison tolerance", MakeTransform(), MakeTransform(rotation: NEGLIGIBLY_DIFFERENT_ROTATION)],
+    ];
+
+    public static IEnumerable<object[]> UnequalTransforms =>
+    [
+        ["a different position", MakeTransform(), MakeTransform(position: DIFFERENT_POSITION)],
+        ["a different rotation", MakeTransform(), MakeTransform(rotation: DIFFERENT_ROTATION)],
+        ["a different scale", MakeTransform(), MakeTransform(scale: DIFFERENT_SCALE)],
+    ];
+
+    public static IEnumerable<object[]> ValuesThatAreNotTransforms =>
+    [
+        ["null", null],
+        ["a string", "not a transform"],
+        ["a RigidTransform carrying the same position and rotation", new RigidTransform(POSITION, ROTATION)],
+    ];
+
+    [TestMethod]
+    [DynamicData(nameof(EqualTransforms))]
+    public void Equals_EqualTransforms_ReturnsTrue(string scenario, Transform a, Transform b)
+    {
+        var actual = a.Equals(b);
+
+        Assert.IsTrue(actual, scenario);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(UnequalTransforms))]
+    public void Equals_UnequalTransforms_ReturnsFalse(string scenario, Transform a, Transform b)
+    {
+        var actual = a.Equals(b);
+
+        Assert.IsFalse(actual, scenario);
+    }
+
+    [TestMethod]
+    public void Equals_SameInstance_ReturnsTrue()
+    {
+        var transform = MakeTransform();
+
+        var actual = transform.Equals(transform);
+
+        Assert.IsTrue(actual);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(EqualTransforms))]
+    public void EqualsObject_EqualTransforms_ReturnsTrue(string scenario, Transform a, Transform b)
+    {
+        var actual = a.Equals((object)b);
+
+        Assert.IsTrue(actual, scenario);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(UnequalTransforms))]
+    public void EqualsObject_UnequalTransforms_ReturnsFalse(string scenario, Transform a, Transform b)
+    {
+        var actual = a.Equals((object)b);
+
+        Assert.IsFalse(actual, scenario);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(ValuesThatAreNotTransforms))]
+    public void EqualsObject_ValueThatIsNotATransform_ReturnsFalse(string description, object other)
+    {
+        var transform = MakeTransform();
+
+        var actual = transform.Equals(other);
+
+        Assert.IsFalse(actual, description);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(EqualTransforms))]
+    public void EqualityOperator_EqualTransforms_ReturnsTrue(string scenario, Transform a, Transform b)
+    {
+        var actual = a == b;
+
+        Assert.IsTrue(actual, scenario);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(UnequalTransforms))]
+    public void EqualityOperator_UnequalTransforms_ReturnsFalse(string scenario, Transform a, Transform b)
+    {
+        var actual = a == b;
+
+        Assert.IsFalse(actual, scenario);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(EqualTransforms))]
+    public void InequalityOperator_EqualTransforms_ReturnsFalse(string scenario, Transform a, Transform b)
+    {
+        var actual = a != b;
+
+        Assert.IsFalse(actual, scenario);
+    }
+
+    [TestMethod]
+    [DynamicData(nameof(UnequalTransforms))]
+    public void InequalityOperator_UnequalTransforms_ReturnsTrue(string scenario, Transform a, Transform b)
+    {
+        var actual = a != b;
+
+        Assert.IsTrue(actual, scenario);
+    }
+}

--- a/Elements.Core/Data Types/RigidTransform.cs
+++ b/Elements.Core/Data Types/RigidTransform.cs
@@ -19,5 +19,7 @@ namespace Elements.Core
 
         public static bool operator ==(RigidTransform a, RigidTransform b) => a.Equals(b);
         public static bool operator !=(RigidTransform a, RigidTransform b) => !a.Equals(b);
+        public override bool Equals(object obj) => obj is RigidTransform other && Equals(other);
+        public override int GetHashCode() => HashCode.Combine(position, rotation);
     }
 }

--- a/Elements.Core/Data Types/Transform.cs
+++ b/Elements.Core/Data Types/Transform.cs
@@ -17,10 +17,14 @@ namespace Elements.Core
             this.scale = scale;
         }
 
-        public bool Equals(Transform other) => position == other.position && rotation == other.rotation && scale == other.scale;
+        public bool Equals(Transform other) =>
+            position == other.position && rotation == other.rotation && scale == other.scale;
 
         public static bool operator ==(Transform a, Transform b) => a.Equals(b);
         public static bool operator !=(Transform a, Transform b) => !a.Equals(b);
+
+        public override bool Equals(object obj) => obj is Transform other && Equals(other);
+        public override int GetHashCode() => HashCode.Combine(position, rotation, scale);
 
         public static implicit operator Renderite.Shared.RenderTransform(Transform t) => new Renderite.Shared.RenderTransform(t.position, t.rotation, t.scale);
         public static implicit operator Transform(Renderite.Shared.RenderTransform t) => new Transform(t.position, t.rotation, t.scale);

--- a/Elements.Core/String/StringSegment.cs
+++ b/Elements.Core/String/StringSegment.cs
@@ -189,6 +189,8 @@ namespace Elements.Core
         public bool Equals(string other, StringComparison comparison) =>
             AsSpan().Equals(other.AsSpan(), comparison);
 
+        public override int GetHashCode() => string.GetHashCode(AsSpan());
+
         public override string ToString()
         {
             // When it's empty, always return empty string, rather than null. This way we do not

--- a/Elements.Core/StringTokenizing/StringSegmentToken.cs
+++ b/Elements.Core/StringTokenizing/StringSegmentToken.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace Elements.Core
@@ -64,6 +62,8 @@ namespace Elements.Core
             }
         }
 
+        public ReadOnlySpan<char> AsSpan() => WholeString.AsSpan(StartIndex, Length);
+
         public StringSegmentToken SubSegment(int startIndex)
         {
             return SubSegment(startIndex, Length - startIndex);
@@ -123,8 +123,8 @@ namespace Elements.Core
 
             // length equals, but they are either different whole strings or different parts
             // perform a comparison of the actual substring
-            return string.Compare(this.WholeString, this.StartIndex, other.WholeString, other.StartIndex, Length)
-                == 0;
+            return string.CompareOrdinal(this.WholeString, this.StartIndex, other.WholeString, other.StartIndex, Length)
+                   == 0;
         }
 
         public override bool Equals(object obj)
@@ -149,6 +149,8 @@ namespace Elements.Core
         {
             return !(a == b);
         }
+
+        public override int GetHashCode() => string.GetHashCode(AsSpan());
     }
 
     public static class StringSegmentTokenExtensions


### PR DESCRIPTION
Hash codes for rotations are not implemented well.

I'm just going to consider hashes of floatQ not part of this PR. I tagged an example test for each object that now implements a badly formed floatQ including hash code.

The tests were initially generated by claude, the library code was hand written but tests are boilerplate heavy. I did remove a lot of its added tests that related to verifying hash codes with transforms, especially where it verified they could be used in hash-based containers.

The horrible resharper tags are my doing, I can remove those if poked. Just makes my editor a bit less grumpy.