### PR TITLE
Fixed command line args not getting passed to the benchmark runner.

### DIFF
--- a/Elements.Core.Benchmark/Program.cs
+++ b/Elements.Core.Benchmark/Program.cs
@@ -1,3 +1,3 @@
-﻿using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Running;
 
-BenchmarkRunner.Run(typeof(Program).Assembly);
+BenchmarkRunner.Run(typeof(Program).Assembly, null, args);


### PR DESCRIPTION
I think it got hit by the clrf issue as well, but it should be fixed with this PR.