### PR TITLE
Updated nuget dependencies in the test assembly, including with code coverage!

### DIFF
--- a/Elements.Core.Tests/Elements.Core.Tests.csproj
+++ b/Elements.Core.Tests/Elements.Core.Tests.csproj
@@ -8,10 +8,11 @@
     <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
-    <PackageReference Include="MSTest" Version="4.2.3" />
-    <PackageReference Include="MSTest.TestAdapter" Version="4.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.3" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="MSTest" Version="4.3.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Elements.Core\Elements.Core.csproj" />


### PR DESCRIPTION
MSTest is a meta package, the other dependencies are already included.

Adding coverlet isn't exactly updating mstest, but let me know if that should get scraped off.

See https://www.nuget.org/packages/MSTest/#dependencies-body-tab
