### PR TITLE
Enumerate Tree Performance Boost

### DIFF
--- a/Elements.Core.Benchmark/Encoding/DataTreeEnumeration.cs
+++ b/Elements.Core.Benchmark/Encoding/DataTreeEnumeration.cs
@@ -1,0 +1,44 @@
+namespace Elements.Core.Benchmark.Encoding;
+
+public class DataTreeEnumeration
+{
+    [ParamsSource(nameof(Nodes))]
+    public DataTreeNode Node { get; set; }
+    public IEnumerable<DataTreeNode> Nodes => [MakeDeepTree(), MakeDeepList()]; 
+    
+    static DataTreeDictionary MakeDeepTree()
+    {
+        var root = new DataTreeDictionary();
+        var current = root;
+        
+        for (int i = 0; i < 1000; i++)
+        {
+            var leaf = new DataTreeDictionary();
+            current.Add($"{i}", leaf);
+            current = leaf;
+        }
+
+        return root;
+    }
+
+    static DataTreeList MakeDeepList()
+    {
+        var root = new DataTreeList();
+        var current = root;
+
+        for (int i = 0; i < 1000; i++)
+        {
+            var leaf = new DataTreeList();
+            current.Add(leaf);
+            current = leaf;
+        }
+
+        return root;
+    }
+
+    [Benchmark]
+    public List<DataTreeNode> IterateAllChildren()
+    {
+        return Node.EnumerateTree().ToList();
+    }
+}

--- a/Elements.Core/Encoding/DataTreeSerializer/Generic Interface/DataTreeDictionary.cs
+++ b/Elements.Core/Encoding/DataTreeSerializer/Generic Interface/DataTreeDictionary.cs
@@ -8,14 +8,7 @@ namespace Elements.Core
 {
     public partial class DataTreeDictionary : DataTreeNode, IEnumerable<KeyValuePair<string, DataTreeNode>>
     {
-        public override IEnumerable<DataTreeNode> EnumerateTree()
-        {
-            yield return this;
-
-            foreach (var child in Children)
-                foreach (var childNode in child.Value.EnumerateTree())
-                    yield return childNode;
-        }
+        protected override IEnumerable<DataTreeNode> DirectChildren() => Children.Count > 0 ? Children.Values : null;
 
         public Dictionary<string, DataTreeNode> Children { get; private set; }
 

--- a/Elements.Core/Encoding/DataTreeSerializer/Generic Interface/DataTreeList.cs
+++ b/Elements.Core/Encoding/DataTreeSerializer/Generic Interface/DataTreeList.cs
@@ -8,14 +8,7 @@ namespace Elements.Core
 {
     public class DataTreeList : DataTreeNode, IEnumerable<DataTreeNode>
     {
-        public override IEnumerable<DataTreeNode> EnumerateTree()
-        {
-            yield return this;
-
-            foreach (var child in Children)
-                foreach (var childNode in child.EnumerateTree())
-                    yield return childNode;
-        }
+        protected override IEnumerable<DataTreeNode> DirectChildren() => Children.Count > 0 ? Children : null;
 
         public int Count => Children.Count;
 

--- a/Elements.Core/Encoding/DataTreeSerializer/Generic Interface/DataTreeNode.cs
+++ b/Elements.Core/Encoding/DataTreeSerializer/Generic Interface/DataTreeNode.cs
@@ -1,13 +1,56 @@
-﻿using System;
-using System.Collections;
+﻿#nullable enable
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
-namespace Elements.Core
+namespace Elements.Core;
+
+public abstract class DataTreeNode
 {
-    public abstract class DataTreeNode
+    /// <summary>
+    /// Returns the direct children of this node, or null if it has no children.
+    /// Returning an empty enumerable is acceptable, but may consume more memory.
+    /// </summary>
+    protected abstract IEnumerable<DataTreeNode>? DirectChildren();
+
+    public IEnumerable<DataTreeNode> EnumerateTree()
     {
-        public abstract IEnumerable<DataTreeNode> EnumerateTree();
+        yield return this;
+        
+        var visits = new Stack<IEnumerator<DataTreeNode>>();
+
+        try
+        {
+            PushChildrenToVisit(this);
+        
+            while (visits.TryPeek(out var enumerator))
+            {
+                if (enumerator.MoveNext())
+                {
+                    var child = enumerator.Current;
+                    yield return child;
+                    PushChildrenToVisit(child);
+                }
+                else
+                {
+                    visits.Pop().Dispose();
+                }
+            }
+        }
+        finally
+        {
+            while (visits.TryPop(out var e)) e.Dispose();
+        }
+
+        yield break;
+
+        void PushChildrenToVisit(DataTreeNode node)
+        {
+            // Enumerator is disposed when it is popped from the stack.
+            // ReSharper disable once GenericEnumeratorNotDisposed
+            var enumerator = node.DirectChildren()?.GetEnumerator();
+            if (enumerator != null)
+            {
+                visits.Push(enumerator);
+            }
+        }
     }
 }

--- a/Elements.Core/Encoding/DataTreeSerializer/Generic Interface/DataTreeValue.cs
+++ b/Elements.Core/Encoding/DataTreeSerializer/Generic Interface/DataTreeValue.cs
@@ -7,10 +7,7 @@ namespace Elements.Core
 {
     public partial class DataTreeValue : DataTreeNode
     {
-        public override IEnumerable<DataTreeNode> EnumerateTree()
-        {
-            yield return this;
-        }
+        protected override IEnumerable<DataTreeNode> DirectChildren() => null;
 
         public IConvertible Value { get; private set; }
 


### PR DESCRIPTION
Now there's a much smaller PR, https://github.com/Yellow-Dog-Man/Elements.Core/pull/58, that adds an order test to the current implementation. This PR builds on top of that one, without changing that test. If it still passes here, the order was unchanged.

Recursive yielding functions make a tree of enumerators, where `MoveNext` calls `MoveNext` on children and so forth, for every node in the depth of the tree.

For the 125 deep nodes here (which I do not think are all that deep), the iteration time goes from 5.186 ms to 15.37 μs, around a 337.42x decrease. The deeper the tree the worse it would be. 'Mushroom' like trees (like an avatar far down a slot hierarchy) would be the worst case, every leaf node would be n depth calls to the `MoveNext` linked list.

Previously it was slightly better than O(n^2), now it should be around O(n), worst case being if the stack in EnumerateTree is grown to the list of all nodes in the tree.

Before:

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8875/25H2/2025Update/HudsonValley2)
13th Gen Intel Core i7-13700K 3.40GHz, 1 CPU, 24 logical and 16 physical cores
.NET SDK 10.0.302
  [Host]     : .NET 10.0.10 (10.0.10, 10.0.1026.32716), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 10.0.10 (10.0.10, 10.0.1026.32716), X64 RyuJIT x86-64-v3


```
| Method             | Node                   | Mean     | Error     | StdDev    | Median   |
|------------------- |----------------------- |---------:|----------:|----------:|---------:|
| **IterateAllChildren** | **Dic(...)\n\r\n [21904]** | **5.186 ms** | **0.1270 ms** | **0.3622 ms** | **5.275 ms** |
| **IterateAllChildren** | **Lis(...)\n\r\n [11008]** | **4.954 ms** | **0.2231 ms** | **0.6578 ms** | **5.216 ms** |


After:

```

BenchmarkDotNet v0.15.8, Windows 11 (10.0.26200.8875/25H2/2025Update/HudsonValley2)
13th Gen Intel Core i7-13700K 3.40GHz, 1 CPU, 24 logical and 16 physical cores
.NET SDK 10.0.302
  [Host]     : .NET 10.0.10 (10.0.10, 10.0.1026.32716), X64 RyuJIT x86-64-v3
  DefaultJob : .NET 10.0.10 (10.0.10, 10.0.1026.32716), X64 RyuJIT x86-64-v3


```
| Method             | Node                   | Mean     | Error    | StdDev   |
|------------------- |----------------------- |---------:|---------:|---------:|
| **IterateAllChildren** | **Dic(...)\n\r\n [21904]** | **15.37 μs** | **0.301 μs** | **0.359 μs** |
| **IterateAllChildren** | **Lis(...)\n\r\n [11008]** | **13.43 μs** | **0.148 μs** | **0.139 μs** |

