### PR TITLE
Marked SingleItemEnumerable as deprecated, newer language constructs support this

### DIFF
--- a/Elements.Core/Collections/SingleItemEnumerable.cs
+++ b/Elements.Core/Collections/SingleItemEnumerable.cs
@@ -48,6 +48,7 @@ namespace Elements.Core
             }
         }
 
+        [Obsolete("Replace with `[item]` from C# 12")]
         public SingleItemEnumerable(T item)
         {
             this.item = item;
@@ -60,6 +61,7 @@ namespace Elements.Core
 
     public static class SingleItemEnumerableHelper
     {
+        [Obsolete("Replace with `[item]` from C# 12")]
         public static SingleItemEnumerable<T> AsSingleItemEnumerable<T>(this T item) => new SingleItemEnumerable<T>(item);
     }
 }


### PR DESCRIPTION
Marked SingleItemEnumerable as deprecated, as it can be replaecd with a collection expression (which makes a span).

See https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/collection-expressions

This hard type will depend on context, but given what this was I'm guessing it will be [System.Span<T>](https://learn.microsoft.com/en-us/dotnet/api/system.span-1) or [System.ReadOnlySpan<T>](https://learn.microsoft.com/en-us/dotnet/api/system.readonlyspan-1).