### PR TITLE
Added a unit-test utility for loading local files

### DIFF
--- a/Elements.Core.Tests/ResourceFiles.cs
+++ b/Elements.Core.Tests/ResourceFiles.cs
@@ -1,0 +1,79 @@
+using System.Runtime.CompilerServices;
+
+namespace Elements.Core.Tests;
+
+/// <summary>
+/// An accessor for file paths for files checked into the repo.
+///
+/// This doesn't work if a test executable is moved to another system.
+/// This is also affected by DeterministicSourcePaths and ContinuousIntegrationBuild props.
+/// 
+/// To fix this, we should probably change to preserveNewest content items in the csproj.
+/// This requires static files to be in the repo first, otherwise the csproj will include nonexistent assets,
+/// and the directory won't be created.
+/// </summary>
+[TestClass]
+public static class ResourceFiles
+{
+    private static readonly Lazy<string> CsprojDir = new (() => {
+        var rootPath = Path.GetFullPath(ThisStaticFilePath());
+        var current = rootPath;
+        while (!File.Exists(Path.Combine(current, typeof(ResourceFiles).Assembly.GetName().Name + ".csproj")))
+        {
+            current = Path.GetDirectoryName(current);
+            if (current == null)
+            {
+                throw new ArgumentException(
+                    $"Could not find Elements.Core.Tests.csproj under '{rootPath}', tests that load local resource will probably fail.");
+            }
+        }
+
+        return current;
+    });
+
+    private static string ThisStaticFilePath([CallerFilePath] string filePath = "") => filePath;
+
+    /// <summary>
+    /// Returns the path to a resource in the Elements.Core.Tests project.
+    /// Resources are relative to the Elements.Core.Tests directory.
+    /// </summary>
+    /// <param name="pathSegments">The segments to append to the path, normally some kind of resource directory, then file name.</param>
+    /// <returns>The fully formed file path.</returns>
+    public static string GetResourcePath(params string[] pathSegments)
+    {
+        return Path.GetFullPath(Path.Combine(CsprojDir.Value, Path.Combine(pathSegments)));
+    }
+
+    /// <summary>
+    /// Returns a path to a resource relative to the file calling the method.
+    /// </summary>
+    /// <param name="fileName">The name of the file to load, this can contain relative paths, but be careful about platform-specific symbols.</param>
+    /// <param name="sourceFile">The path to the file calling this method, DO NOT PROVIDE THIS ARGUMENT.</param>
+    /// <returns>The fully formed file path.</returns>
+    public static string GetLocalResourcePath(string fileName, [CallerFilePath] string sourceFile = "")
+    {
+        // This is belts and suspenders, sourceFile is a full path,
+        // so combining the csproj dir to sourceFile would only result in sourceFile.
+        // If someone manually provides the sourceFile parameter, this helps avoid breaking out of the directory.
+        // This should also allow files from other assemblies to be loaded (like the benchmarks).
+        return Path.GetFullPath(Path.Combine(CsprojDir.Value, sourceFile, "..", fileName));
+    }
+}
+
+[TestClass]
+public class ResourceFilesTests
+{
+    [TestMethod]
+    public void GetResourcePath_ExistingFile_ReturnsPathToFile()
+    {
+        var path = ResourceFiles.GetResourcePath("ResourceFiles.cs");
+        Assert.IsTrue(File.Exists(path));
+    }
+
+    [TestMethod]
+    public void GetLocalResourcePath_ExistingFile_ReturnsPathToFile()
+    {
+        var path = ResourceFiles.GetLocalResourcePath("ResourceFiles.cs");
+        Assert.IsTrue(File.Exists(path));
+    }
+}

--- a/Elements.Core.Tests/TempFiles.cs
+++ b/Elements.Core.Tests/TempFiles.cs
@@ -1,0 +1,116 @@
+namespace Elements.Core.Tests;
+
+/// <summary>
+/// A creator and cleanup class for directories to create temp files and directories during tests.
+///
+/// Cleanup happens on the following run, artifacts are left in the temp directory.
+/// </summary>
+[TestClass]
+public static class TempFiles
+{
+    private static readonly string TempRoot;
+
+    static string TempRootPath() => Path.Combine(AppContext.BaseDirectory, "TestTemp");
+
+    static TempFiles()
+    {
+        TempRoot = Path.Combine(TempRootPath(),
+            $"{DateTime.UtcNow:yyyy-MM-dd_HH.mm.ss}_{Path.GetRandomFileName()}");
+    }
+
+    [AssemblyInitialize]
+    public static void AssemblyInit(TestContext testContext)
+    {
+        if (!Directory.Exists(TempRootPath()))
+        {
+            return;
+        }
+        
+        foreach (var dir in Directory.EnumerateDirectories(TempRootPath()))
+        {
+            try
+            {
+                Directory.Delete(dir, true);
+            }
+            catch (Exception e)
+            {
+                testContext.WriteLine($"Failed to delete previous test directory {dir}: {e.Message}");
+            }
+        }
+    }
+
+    /// <summary>
+    /// Creates a temp directory for a test.
+    /// 
+    /// The contents of the directory are deleted when the next run begins.
+    /// <paramref name="path"/> should be used to prevent tests from running into each other.
+    /// </summary>
+    /// <param name="path">The relative path segments to append to the temp directory.</param>
+    /// <returns>The full directory path the test can mutate.</returns>
+    public static string CreateTempDir(params ReadOnlySpan<string> path)
+    {
+        var leafPath = Path.Combine(path);
+        var fullPath = Path.GetFullPath(Path.Combine(TempRoot, leafPath));
+        if (TempRoot != fullPath &&
+            !fullPath.StartsWith(TempRoot + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+        {
+            throw new ArgumentException(
+                $"Temp path '{leafPath}' moved out of the temp directory, which is not allowed.", nameof(path));
+        }
+
+        Directory.CreateDirectory(fullPath);
+        return fullPath;
+    }
+
+    /// <summary>
+    /// Create a temp directory for the test; bucketed by the type name provided (normally the test fixture type).
+    /// 
+    /// The contents of the directory are deleted when the next run begins.
+    /// <paramref name="path"/> should be used to prevent tests from running into each other.
+    /// </summary>
+    /// <param name="path">The relative path segments to append to the temp directory.</param>
+    /// <typeparam name="T">A type to isolate temp files, the name of the type goes between the temp dir root and the path segments provided.</typeparam>
+    /// <returns>The full directory path the test can mutate.</returns>
+    public static string CreateTempDir<T>(params ReadOnlySpan<string> path)
+    {
+        return CreateTempDir([typeof(T).Name, .. path]);
+    }
+}
+
+[TestClass]
+public class TempFilesTests
+{
+    [TestMethod]
+    public void CreateTempDir_EmptyPath_RootTempDirExists()
+    {
+        var path = TempFiles.CreateTempDir();
+        Assert.IsTrue(Directory.Exists(path));
+    }
+
+    [TestMethod]
+    public void CreateTempDir_WithoutSpecifier_CreatesNestedTempDir()
+    {
+        var path = TempFiles.CreateTempDir("Tacos", "Trees");
+        Assert.IsTrue(Directory.Exists(path));
+        Assert.EndsWith("Trees", path);
+    }
+
+    [TestMethod]
+    public void CreateTempDir_WithType_CreatesSpecializedTargetDir()
+    {
+        var path = TempFiles.CreateTempDir<TempFilesTests>();
+        Assert.IsTrue(Directory.Exists(path));
+    }
+
+    [TestMethod]
+    public void CreateTempDir_RootedPath_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => TempFiles.CreateTempDir("/Tacos", "Trees"));
+    }
+
+    [TestMethod]
+    public void CreateTempDir_UpwardsPath_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() => TempFiles.CreateTempDir("..", "Trees"));
+    }
+}


### PR DESCRIPTION
Added a utility to help with file discovery for unit tests.

This should remove the need for files to be embedded into the test assembly, or copied to the test output.

It's a bit non-standard, more normal practice is to copy-always or embed them as resources, but from my experience it's been easy to get wrong. This may be better, but if it fails it can be swapped back to one of those.

This is a pre-emptive answer to https://github.com/Yellow-Dog-Man/Elements.Core/issues/39 , but can shift to whatever direction temp files end up going.

