### PR TITLE
Add IReadOnlyList<T> interfaces to RawList & RawValueList

### DIFF
--- a/Elements.Core/Collections/RawList.cs
+++ b/Elements.Core/Collections/RawList.cs
@@ -9,7 +9,7 @@ namespace Elements.Core
     /// No-frills list that wraps an accessible array.
     ///</summary>
     ///<typeparam name="T">Type of elements contained by the list.</typeparam>
-    public class RawList<T> : IList<T>
+    public class RawList<T> : IList<T>, IReadOnlyList<T>
     {
         ///<summary>
         /// Direct access to the elements owned by the raw list.

--- a/Elements.Core/Collections/RawValueList.cs
+++ b/Elements.Core/Collections/RawValueList.cs
@@ -10,7 +10,7 @@ namespace Elements.Core
     /// No-frills list that wraps an accessible array.
     ///</summary>
     ///<typeparam name="T">Type of elements contained by the list.</typeparam>
-    public class RawValueList<T> : IList<T>
+    public class RawValueList<T> : IList<T>, IReadOnlyList<T>
         where T : struct
     {
         ///<summary>


### PR DESCRIPTION
Follow-up, in FrooxEngine those are used with the extension methods. This makes them work again.