### PR TITLE
Added a unit test to verify enumerator order

### DIFF
--- a/Elements.Core.Tests/Encoding/Generic Interface/DataTreeNodeTests.cs
+++ b/Elements.Core.Tests/Encoding/Generic Interface/DataTreeNodeTests.cs
@@ -1,0 +1,78 @@
+namespace Elements.Core.Tests;
+
+[TestClass]
+public class DataTreeNodeTests
+{
+    private static DataTreeDictionary MakeNumericTree()
+    {
+        return new DataTreeDictionary
+        {
+            { "a", 1 },
+            {
+                "b", new DataTreeList
+                {
+                    new DataTreeDictionary
+                    {
+                        { "a", 2 },
+                        { "b", 3 },
+                        { "c", 4 }
+                    },
+                    new DataTreeDictionary
+                    {
+                        { "a", 5 },
+                        {
+                            "b", new DataTreeList
+                            {
+                                new DataTreeDictionary
+                                {
+                                    { "a", 6 },
+                                    { "b", 7 },
+                                    { "c", 8 }
+                                },
+                                new DataTreeDictionary
+                                {
+                                    { "a", 9 },
+                                    { "b", 10 },
+                                    { "c", 11 }
+                                }
+                            }
+                        },
+                        { "c", 12 },
+                        { "d", 13 },
+                    },
+                    new DataTreeDictionary
+                    {
+                        { "a", 14 },
+                        { "b", 15 },
+                        { "c", 16 }
+                    }
+                }
+            },
+            { "c", 17 },
+            {
+                "d",
+                new DataTreeDictionary
+                {
+                    { "a", 18 },
+                    { "b", 19 },
+                    { "c", 20 }
+                }
+            },
+            { "e", 21 },
+            { "f", 22 },
+        };
+    }
+
+    // WARNING: This test may break if the dictionaries in DataTreeDictionary reorder their keys.
+    // If this test fails randomly, just ensure the iteration is some form of depth-first.
+    [TestMethod]
+    public void EnumerateTree_MultiLevelTree_MatchesKnownEnumerationOrder()
+    {
+        var nodes = MakeNumericTree();
+
+        var numbers = nodes.EnumerateTree().OfType<DataTreeValue>().Select(v => v.LoadInt()).ToArray();
+        var expected = Enumerable.Range(1, 22).ToArray();
+
+        Assert.AreSequenceEqual(expected, numbers);
+    }
+}

--- a/Elements.Core/Encoding/DataTreeSerializer/Generic Interface/DataTreeDictionary.cs
+++ b/Elements.Core/Encoding/DataTreeSerializer/Generic Interface/DataTreeDictionary.cs
@@ -1,11 +1,12 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
 namespace Elements.Core
 {
-    public partial class DataTreeDictionary : DataTreeNode
+    public partial class DataTreeDictionary : DataTreeNode, IEnumerable<KeyValuePair<string, DataTreeNode>>
     {
         public override IEnumerable<DataTreeNode> EnumerateTree()
         {
@@ -132,5 +133,9 @@ namespace Elements.Core
 
             return str.ToString();
         }
+
+        public IEnumerator<KeyValuePair<string, DataTreeNode>> GetEnumerator() => Children.GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }


### PR DESCRIPTION
This came up in https://github.com/Yellow-Dog-Man/Elements.Core/pull/33 where that PR was based on a unit test PR that under more investigation didn't relate to the enumerators anyways!

This PR acts as a base-case for https://github.com/Yellow-Dog-Man/Elements.Core/pull/33. This PR has the tests proving the iterators order, and that PR will use the same test.

Technically this PR should go in first, but if 33 goes in first, this PR should get auto-closed by github.