### PR TITLE
Fixed Yellow-Dog-Man/Resonite-Issues#7112 (`Coder.Equals<T?>.Equals(null,null)` was false, should have been true)

### DIFF
--- a/Elements.Core.Tests/Nullable/CoderNullable.cs
+++ b/Elements.Core.Tests/Nullable/CoderNullable.cs
@@ -1,0 +1,16 @@
+﻿namespace Elements.Core.Tests
+{
+    [TestClass]
+    public class CoderNullable
+    {
+        [TestMethod]
+        public void TestEquals()
+        {
+            Assert.IsTrue(Coder<int?>.Equals(null, null), conditionExpression: "null == null");
+            Assert.IsFalse(Coder<int?>.Equals(1, null), conditionExpression: "1 != null");
+            Assert.IsFalse(Coder<int?>.Equals(null, 1), conditionExpression: "null != 1");
+            Assert.IsTrue(Coder<int?>.Equals(1, 1), conditionExpression: "1 == 1");
+            Assert.IsFalse(Coder<int?>.Equals(1, 2), conditionExpression: "1 != 2");
+        }
+    }
+}

--- a/Elements.Core/CoderNullable.cs
+++ b/Elements.Core/CoderNullable.cs
@@ -40,7 +40,7 @@ namespace Elements.Core
             if (a.HasValue != b.HasValue)
                 return false;
             if (!a.HasValue)
-                return false;
+                return true;
 
             return Coder<T>.Equals(a.Value, b.Value);
         }


### PR DESCRIPTION
I added a test that failed before the bug was fixed and fixed the bug itself.